### PR TITLE
Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,76 @@ The following mutations are called automatically by the service actions, and wil
 
 ### Service Actions
 An action is included for each of the Feathers service interface methods.  These actions will affect changes in both the Feathers API server and the Vuex store.
-- `find`: query an array of records from the server & add to Vuex store
-- `get`: query a single record from the server & add to Vuex store
-- `create`: create one (as an object) or multiple (as an array) records
-- `update`: update (overwrite) a record
-- `patch`: patch (merge in changes) one or more records
-- `remove`: remove/delete the record
 
-### Getters
-Each service that is setup with Vuex will have the following getters:
-- `find`: accepts a `params` object which allows you to use the [Feathers query syntax]() to query an array of records from the Vuex store.
-- `get`: similar to `find`, but allows you to query a single record from the Vuex store.
+All of the [Feathers Service Methods](https://docs.feathersjs.com/api/databases/common.html#service-methods) are supported.  Because Vuex only supports providing a single argument to actions, there is a slight change in syntax that works well.  If you need to pass multiple arguments to a service method, pass an array to the action with the order of the array elements matching the order of the arguments.  See each method for examples.
+
+> Note: If you use the Feathers service methods, directly, the store will not change. Only the actions will cause store changes.
+
+#### `find(params)`
+Query an array of records from the server & add to the Vuex store.
+- `params {Object}` - An object containing a `query` object.
+
+```js
+let params = {query: {completed: true}}
+store.dispatch('todos/find', params)
+```
+
+#### `get(id)` or `get([id, params])`
+Query a single record from the server & add to Vuex store
+- `id {Number|String}` - the `id` of the record being requested from the API server.
+- `params {Object}` - An object containing a `query` object.
+
+```js
+store.dispatch('todos/get', 1)
+
+// Use an array to pass params
+let params = {}
+store.dispatch('todos/get', [1, params])
+```
+
+#### `create(data)`
+Create one or multiple records.
+- `data {Object|Array}` - if an object is provided, a single record will be created. If an array of objects is provided, multiple records will be created.
+
+```js
+let newTodo = {description: 'write good tests'}
+store.dispatch('todos/create', newTodo)
+```
+
+
+#### `update([id, data, params])`
+Update (overwrite) a record.
+- `id {Number|String}` - the `id` of the existing record being requested from the API server.
+- `data {Object}` - the data that will overwrite the existing record
+- `params {Object}` - An object containing a `query` object.
+
+```js
+let data = {id: 5, description: 'write your tests', completed: true}
+let params = {}
+// Overwrite item 1 with the above data (FYI: Most databases won't let you change the id.)
+store.dispatch('todos/update', [1, data, params])
+```
+
+#### `patch([id, data, params])`
+Patch (merge in changes) one or more records
+- `id {Number|String}` - the `id` of the existing record being requested from the API server.
+- `data {Object}` - the data that will be merged into the existing record
+- `params {Object}` - An object containing a `query` object.
+
+```js
+let data = {description: 'write your tests', completed: true}
+let params = {}
+store.dispatch('todos/update', [1, data, params])
+```
+
+
+#### `remove(id)`
+Remove/delete the record with the given `id`.
+- `id {Number|String}` - the `id` of the existing record being requested from the API server.
+
+```js
+store.dispatch('todos/remove', 1)
+```
 
 ## Auth Module
 The Auth module helps setup your app for login / logout.  It includes the following state by default:

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -28,14 +28,18 @@ export default function makeServiceActions (service) {
       return request.subscribe ? request.subscribe(handleResponse) : request.then(handleResponse)
     },
 
-    get ({ commit, dispatch }, params) {
-      var id = null
-      if (typeof params === 'string' || typeof params === 'number') {
-        id = params
-        params = {}
-      } else if (params && typeof params[idField] !== 'undefined') {
-        id = params[idField]
-        delete params[idField]
+    // Two query syntaxes are supported, since actions only receive onee argument.
+    //   1. Just pass the id: `get(1)`
+    //   2. Pass arguments as an array: `get([null, params])`
+    get ({ commit, dispatch }, args) {
+      let id
+      let params
+
+      if (Array.isArray(args)) {
+        id = args[0]
+        params = args[1]
+      } else {
+        id = args
       }
 
       commit('setGetPending')

--- a/test/service-module/actions.test.js
+++ b/test/service-module/actions.test.js
@@ -62,13 +62,14 @@ describe('Service Module - Actions', () => {
     assert(todoState.idField === 'id')
     assert(todoState.service)
 
+    // Calling a service directly won't update the store.
     feathersClient.service('todos').create([
       { description: 'Do the dishes' },
       { description: 'Do the laundry' },
       { description: 'Do all the things' }
     ])
     .then(response => {
-      actions.get.call({$store: store}, {id: 0})
+      actions.get.call({$store: store}, 0)
       .then(response => {
         assert(todoState.ids.length === 1)
         assert(todoState.errorOnGet === undefined)
@@ -77,7 +78,18 @@ describe('Service Module - Actions', () => {
           0: { id: 0, description: 'Do the dishes' }
         }
         assert.deepEqual(todoState.keyedById, expectedKeyedById)
-        done()
+
+        // Make a request with the array syntax that allows passing params
+        actions.get.call({$store: store}, [1, {}])
+          .then(response2 => {
+            expectedKeyedById = {
+              0: { id: 0, description: 'Do the dishes' },
+              1: { id: 1, description: 'Do the laundry' }
+            }
+            assert(response2.description === 'Do the laundry')
+            assert.deepEqual(todoState.keyedById, expectedKeyedById)
+            done()
+          })
       })
 
       // Make sure proper state changes occurred before response


### PR DESCRIPTION
Changes the `get` action supported syntax to either an `id` or an array if `params` need to be pass, as well.

Also adds better API docs for all actions.