### PR TITLE
Fix clearList unexpected behavior. Closes #5

### DIFF
--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -112,10 +112,16 @@ export default function makeServiceMutations (service) {
     clearList (state) {
       let currentId = state.currentId
       let current = state.keyedById[currentId]
-      state.keyedById = {
-        [currentId]: current
+
+      if (currentId && current) {
+        state.keyedById = {
+          [currentId]: current
+        }
+        state.ids = [currentId]
+      } else {
+        state.keyedById = {}
+        state.ids = []
       }
-      state.ids = [currentId]
     },
 
     setCurrent (state, item) {


### PR DESCRIPTION
`clearList` mutation defines the `list` as an array with a single `undefined` element when `current` is not defined.