### PR TITLE
Node: Keep functions out of Vuex state

### DIFF
--- a/mocha.opts
+++ b/mocha.opts
@@ -1,3 +1,2 @@
 --compilers js:babel-core/register
---debug-brk
-test/index.test.js
+test/node.test.js

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "compile": "shx rm -rf lib/ && babel -d lib/ src/",
     "watch": "shx rm -rf lib/ && babel --watch -d lib/ src/",
     "lint": "standard src/**/*.js test/**/*.js --fix",
-    "mocha": "mocha --opts mocha.opts",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run lint && npm run testee",
+    "test-node": "mocha --opts mocha.opts",
     "testee": "testee test/index.html --browsers firefox",
     "start": "npm run compile && node example/app"
   },

--- a/src/feathers-module/feathers-module.js
+++ b/src/feathers-module/feathers-module.js
@@ -1,5 +1,6 @@
 import setupMutations from './mutations'
 import { mapMutations } from 'vuex'
+import { isBrowser } from '../utils'
 
 export default function setupFeathersModule (store, options) {
   if (!options.feathers || !options.feathers.namespace) {
@@ -9,13 +10,18 @@ export default function setupFeathersModule (store, options) {
   const moduleName = options.feathers.namespace
 
   return feathers => {
+    const services = {
+      vuex: {}
+    }
+
+    if (isBrowser) {
+      services.all = feathers.services
+    }
+
     store.registerModule(moduleName, {
       namespaced: true,
       state: {
-        services: {
-          all: feathers.services,
-          vuex: {}
-        }
+        services
       },
       mutations: setupMutations(options)
     })

--- a/src/utils.js
+++ b/src/utils.js
@@ -69,3 +69,8 @@ export function makeConfig (options, modules) {
     return service
   }
 }
+
+// from https://github.com/iliakan/detect-node
+export const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'
+
+export const isBrowser = !isNode

--- a/test/feathers-module/feathers-module.test.js
+++ b/test/feathers-module/feathers-module.test.js
@@ -1,6 +1,7 @@
 import assert from 'chai/chai'
 import feathersVuex from '~/src/index'
 import makeStore from '../fixtures/store'
+import { isNode, isBrowser } from '../../src/utils'
 import { makeFeathersRestClient } from '../fixtures/feathers-client'
 
 describe('Feathers Module', () => {
@@ -55,6 +56,16 @@ describe('Feathers Module', () => {
         .configure(feathersVuex(store))
       var todoService = feathersClient.service('api/todos')
       assert(store.state.feathers.services.vuex['api/todos'] === todoService)
+    })
+  })
+
+  describe('Utils', () => {
+    it('sets isNode to false', () => {
+      assert(!isNode, 'isNode was false')
+    })
+
+    it('sets isBrowser to true', () => {
+      assert(isBrowser, 'isBrowser was true')
     })
   })
 })

--- a/test/node.test.js
+++ b/test/node.test.js
@@ -1,26 +1,20 @@
 
 import chai from 'chai/chai'
-import 'steal-mocha'
 import store from './fixtures/store'
+import { isNode, isBrowser } from '../src/utils'
 // import feathersVuex from '../src/index'
 // require('./vuex.test.js')
 
 const assert = chai.assert
 
 describe('feathers-vuex', () => {
-  it('is CommonJS compatible', () => {
-    assert(typeof require('../lib') === 'function')
-  })
+  describe('Utils', () => {
+    it('sets isNode to true', () => {
+      assert(isNode, 'isNode was true')
+    })
 
-  it('basic functionality', () => {
-    assert(typeof feathersVuex === 'function', 'It worked')
-  })
-
-  describe('Store', () => {
-    it('responds to commits', () => {
-      var state = store.state
-      store.commit('increment')
-      assert(state.count === 1)
+    it('sets isBrowser to false', () => {
+      assert(!isBrowser, 'isBrowser was false')
     })
   })
 })


### PR DESCRIPTION
This adds `isNode` and `isBrowser` utilities and uses them to conditionally add the `all` alias to the Feathers services in the feathers-module.  This prevents the circular JSON problem when serializing in Nuxt SSR.

Related to https://github.com/feathersjs/feathers-vuex/issues/8