### PR TITLE
Bugfix - add params to patch action service call

### DIFF
--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -94,7 +94,7 @@ export default function makeServiceActions (service) {
     patch ({ commit, dispatch }, [id, data, params]) {
       commit('setPatchPending')
 
-      return service.patch(id, data)
+      return service.patch(id, data, params)
         .then(item => {
           dispatch('addOrUpdate', item)
           commit('unsetPatchPending')


### PR DESCRIPTION
Params parameter was not forwarded to the service call from the dispatch method, just added the parameter to the call.