### PR TITLE
QuickFix: Use idField for removal

### DIFF
--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -138,7 +138,7 @@ export default function makeServiceActions (service) {
 
       // Find IDs from the state which are not in the list
       state.ids.forEach(id => {
-        if (!list.some(c => c.id === id)) {
+        if (!list.some(item => item[idField] === id)) {
           toRemove.push(state.keyedById[id])
         }
       })

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -138,7 +138,7 @@ export default function makeServiceActions (service) {
 
       // Find IDs from the state which are not in the list
       state.ids.forEach(id => {
-        if (!list.some(item => item[idField] === id)) {
+        if (id !== state.currentId && !list.some(item => item[idField] === id)) {
           toRemove.push(state.keyedById[id])
         }
       })


### PR DESCRIPTION
The toRemove list in the addOrUpdateList action was built using a hard coded value for the id instead of the idField.