### PR TITLE
Opt in to `autoRemove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ To see `feathers-vuex` in a working vue-cli application, check out [`feathers-ch
 
 ## API Documentation
 
+### Global Configuration
+
+The following default options are available for configuration:
+
+```js
+const defaultOptions = {
+  idField: 'id', // The field in each record that will contain the id
+  auto: true, // automatically setup a store for each service.
+  autoRemove: false, // automatically remove records missing from responses (only use with feathers-rest)
+  nameStyle: 'short', // Determines the source of the module name. 'short', 'path', or 'explicit'
+  feathers: {
+    namespace: 'feathers'
+  },
+  auth: {
+    namespace: 'auth',
+    userService: '', // Set this to automatically populate the user on login success.
+    state: {}, // add custom state to the auth module
+    getters: {}, // add custom getters to the auth module
+    mutations: {}, // add custom mutations to the auth module
+    actions: {} // add custom actions to the auth module
+  }
+}
+```
+
+Each service module can also be individually configured.
+
+### The Vuex modules
+
 There are three modules included:
 1. The Feathers module keeps a list of all services with vuex stores attached.
 2. The Service module adds a Vuex store for new services.

--- a/src/index.js
+++ b/src/index.js
@@ -7,21 +7,20 @@ import clone from 'clone'
 import { normalizePath, makeConfig, isBrowser } from './utils'
 
 const defaultOptions = {
-  idField: 'id',
-  auto: true,
-  autoForce: false,
-  // Determines the source of the module name. 'short', 'path', or 'explicit'
-  nameStyle: 'short',
+  idField: 'id', // The field in each record that will contain the id
+  auto: true, // automatically setup a store for each service.
+  autoRemove: false, // automatically remove records missing from responses (only use with feathers-rest)
+  nameStyle: 'short', // Determines the source of the module name. 'short', 'path', or 'explicit'
   feathers: {
     namespace: 'feathers'
   },
   auth: {
     namespace: 'auth',
-    userService: '',
-    state: {},
-    getters: {},
-    mutations: {},
-    actions: {}
+    userService: '', // Set this to automatically populate the user on login success.
+    state: {}, // add custom state to the auth module
+    getters: {}, // add custom getters to the auth module
+    mutations: {}, // add custom mutations to the auth module
+    actions: {} // add custom actions to the auth module
   }
 }
 

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -137,7 +137,7 @@ export default function makeServiceActions (service) {
       const toUpdate = []
       const toRemove = [] // Added
 
-      if (!isPaginated) {
+      if (!isPaginated && vuexOptions.global.autoRemove) {
         // Find IDs from the state which are not in the list
         state.ids.forEach(id => {
           if (id !== state.currentId && !list.some(item => item[idField] === id)) {

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -6,8 +6,7 @@ export default function makeServiceActions (service) {
     find ({ commit, dispatch }, params) {
       commit('setFindPending')
       const handleResponse = response => {
-        let data = response.data || response
-        dispatch('addOrUpdateList', data)
+        dispatch('addOrUpdateList', response)
         commit('unsetFindPending')
         return response
       }
@@ -131,17 +130,21 @@ export default function makeServiceActions (service) {
   }
 
   const actions = {
-    addOrUpdateList ({ state, commit }, list) {
-      let toAdd = []
-      let toUpdate = []
-      let toRemove = [] // Added
+    addOrUpdateList ({ state, commit }, response) {
+      const list = response.data || response
+      const isPaginated = response.hasOwnProperty('total')
+      const toAdd = []
+      const toUpdate = []
+      const toRemove = [] // Added
 
-      // Find IDs from the state which are not in the list
-      state.ids.forEach(id => {
-        if (id !== state.currentId && !list.some(item => item[idField] === id)) {
-          toRemove.push(state.keyedById[id])
-        }
-      })
+      if (!isPaginated) {
+        // Find IDs from the state which are not in the list
+        state.ids.forEach(id => {
+          if (id !== state.currentId && !list.some(item => item[idField] === id)) {
+            toRemove.push(state.keyedById[id])
+          }
+        })
+      }
 
       list.forEach(item => {
         let id = item[idField]

--- a/test/fixtures/todos.js
+++ b/test/fixtures/todos.js
@@ -1,5 +1,7 @@
-module.exports = {
-  1: { _id: 1, description: 'Dishes', isComplete: true },
-  2: { _id: 2, description: 'Laundry', isComplete: true },
-  3: { _id: 3, description: 'Groceries', isComplete: true }
+module.exports = function makeTodos () {
+  return {
+    1: { _id: 1, description: 'Dishes', isComplete: true },
+    2: { _id: 2, description: 'Laundry', isComplete: true },
+    3: { _id: 3, description: 'Groceries', isComplete: true }
+  }
 }

--- a/test/fixtures/todos.js
+++ b/test/fixtures/todos.js
@@ -1,0 +1,5 @@
+module.exports = {
+  1: { _id: 1, description: 'Dishes', isComplete: true },
+  2: { _id: 2, description: 'Laundry', isComplete: true },
+  3: { _id: 3, description: 'Groceries', isComplete: true }
+}

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -24,6 +24,7 @@ describe('Service Module', () => {
       const expectedGlobal = {
         idField: 'id',
         auto: true,
+        autoRemove: false,
         nameStyle: 'short',
         feathers: {
           namespace: 'feathers'

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -3,6 +3,7 @@ import feathersVuex from '~/src/index'
 import makeStore from '../fixtures/store'
 import { makeFeathersRestClient } from '../fixtures/feathers-client'
 import memory from 'feathers-memory'
+import todos from '../fixtures/todos'
 
 describe('Service Module', () => {
   describe('Configuration', () => {
@@ -139,6 +140,27 @@ describe('Service Module', () => {
       assert(todoState.error === undefined)
       assert(todoState.idField === '_id')
       assert.deepEqual(todoState.keyedById, {})
+    })
+
+    it(`populates items on find`, function (done) {
+      const store = makeStore()
+      makeFeathersRestClient()
+        .configure(feathersVuex(store, {idField: '_id'}))
+        .service('todos', memory({store: todos}))
+
+      const todoState = store.state.todos
+
+      assert(todoState.ids.length === 0)
+
+      store.dispatch('todos/find', { query: {} })
+        .then(todos => {
+          assert(todoState.ids.length === 3)
+          done()
+        })
+        .catch(error => {
+          assert(!error, error.message)
+          done()
+        })
     })
   })
 })


### PR DESCRIPTION
In version `0.4.0`, an `autoRemove` feature was introduced.  In `0.5.0, this feature is opt-in only.  It's intended only for use with feathers-rest.  When using feathers-socketio, the socket messages and feathers-reactive should automatically take care of removal from the store.

The new option can be used by setting `autoRemove` to `true` in the global options. 

```
feathersClient.configure(feathersVuex(store, { autoRemove: true }))
```

Closes #19 
Closes #21 