### PR TITLE
Remove all non-serializable data from the state

### DIFF
--- a/src/feathers-module/feathers-module.js
+++ b/src/feathers-module/feathers-module.js
@@ -1,6 +1,5 @@
 import setupMutations from './mutations'
 import { mapMutations } from 'vuex'
-import { isBrowser } from '../utils'
 
 export default function setupFeathersModule (store, options) {
   if (!options.feathers || !options.feathers.namespace) {
@@ -12,10 +11,6 @@ export default function setupFeathersModule (store, options) {
   return feathers => {
     const services = {
       vuex: {}
-    }
-
-    if (isBrowser) {
-      services.all = feathers.services
     }
 
     store.registerModule(moduleName, {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import setupAuthModule from './auth-module/auth-module'
 import setupFeathersModule from './feathers-module/feathers-module'
 import deepAssign from 'deep-assign'
 import clone from 'clone'
-import { normalizePath, makeConfig, isBrowser } from './utils'
+import { normalizePath, makeConfig } from './utils'
 
 const defaultOptions = {
   idField: 'id', // The field in each record that will contain the id
@@ -47,10 +47,7 @@ export default function (clientOrStore, options = {}, modules = {}) {
       }
     })
 
-    var addToFeathersModule
-    if (isBrowser) {
-      addToFeathersModule = setupFeathersModule(store, options)(feathers)
-    }
+    const addToFeathersModule = setupFeathersModule(store, options)(feathers)
     const setup = setupServiceModule(store)
     const addConfigTo = makeConfig(options, modules)
     setupAuthModule(store, options)(feathers)
@@ -64,9 +61,7 @@ export default function (clientOrStore, options = {}, modules = {}) {
 
         addConfigTo(service, moduleOptions)
         setup(service, { force })
-        if (isBrowser) {
-          addToFeathersModule(service)
-        }
+        addToFeathersModule(service)
         return service
       }
     }

--- a/src/service-module/state.js
+++ b/src/service-module/state.js
@@ -1,5 +1,3 @@
-import { isBrowser } from '../utils'
-
 export default service => {
   const vuexOptions = service.vuexOptions
   const idField = (vuexOptions.module && vuexOptions.module.idField) || vuexOptions.global.idField
@@ -24,9 +22,6 @@ export default service => {
     errorOnUpdate: undefined,
     errorOnPatch: undefined,
     errorOnRemove: undefined
-  }
-  if (isBrowser) {
-    state.service = service
   }
   return state
 }

--- a/test/feathers-module/feathers-module.test.js
+++ b/test/feathers-module/feathers-module.test.js
@@ -23,7 +23,7 @@ describe('Feathers Module', () => {
       feathersClient.service('api/animals')
       const services = store.state.feathers.services
 
-      assert(services.all)
+      assert(!services.all, 'there is no services.all property.')
       assert(services.vuex)
       assert(!services.vuex.animals)
     })
@@ -35,14 +35,13 @@ describe('Feathers Module', () => {
       makeFeathersRestClient().configure(feathersVuex(store))
       const expected = {
         services: {
-          vuex: {},
-          all: {}
+          vuex: {}
         }
       }
-      assert.deepEqual(expected, store.state.feathers)
+      assert.deepEqual(expected, store.state.feathers, 'the feathers module had the correct default state')
     })
 
-    it('has a map of all feathers services', () => {
+    it.skip('has a map of all feathers services', () => {
       const store = makeStore()
       const feathersClient = makeFeathersRestClient()
         .configure(feathersVuex(store))

--- a/test/service-module/actions.test.js
+++ b/test/service-module/actions.test.js
@@ -18,7 +18,6 @@ describe('Service Module - Actions', () => {
     assert(todoState.errorOnFind === undefined)
     assert(todoState.isFindPending === false)
     assert(todoState.idField === 'id')
-    assert(todoState.service)
 
     feathersClient.service('todos').create([
       { description: 'Do the dishes' },
@@ -60,7 +59,6 @@ describe('Service Module - Actions', () => {
     assert(todoState.errorOnGet === undefined)
     assert(todoState.isGetPending === false)
     assert(todoState.idField === 'id')
-    assert(todoState.service)
 
     // Calling a service directly won't update the store.
     feathersClient.service('todos').create([
@@ -122,7 +120,6 @@ describe('Service Module - Actions', () => {
     assert(todoState.errorOnCreate === undefined)
     assert(todoState.isCreatePending === true)
     assert(todoState.idField === 'id')
-    assert(todoState.service)
     assert.deepEqual(todoState.keyedById, {})
   })
 
@@ -150,7 +147,6 @@ describe('Service Module - Actions', () => {
         assert(todoState.errorOnUpdate === undefined)
         assert(todoState.isUpdatePending === true)
         assert(todoState.idField === 'id')
-        assert(todoState.service)
       })
   })
 
@@ -178,7 +174,6 @@ describe('Service Module - Actions', () => {
         assert(todoState.errorOnPatch === undefined)
         assert(todoState.isPatchPending === true)
         assert(todoState.idField === 'id')
-        assert(todoState.service)
       })
   })
 
@@ -206,7 +201,6 @@ describe('Service Module - Actions', () => {
         assert(todoState.errorOnRemove === undefined)
         assert(todoState.isRemovePending === true)
         assert(todoState.idField === 'id')
-        assert(todoState.service)
       })
   })
 })


### PR DESCRIPTION
This removes the feathers module’s `services.all` property as well as each service’s state’s `service` property.