### PR TITLE
Allow customizing a service’s default store

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `Feathers Module` allows your application to peer into how the Feathers clie
 ```
 
 ## Service Module
-The `Service Module` automatically sets up newly-created services into the Vuex store.
+The `Service Module` automatically sets up newly-created services into the Vuex store.  Each service will have the below default state in its store. The service will also have a `vuex` method that will allow you to add custom `state`, `getters`, `mutations`, and `actions` to an individual service's store.
 
 ### Service State
 Each service comes loaded with the following default state:
@@ -322,6 +322,37 @@ Remove/delete the record with the given `id`.
 
 ```js
 store.dispatch('todos/remove', 1)
+```
+
+## Customizing a Service's Default Store
+
+Each registered service will have a `vuex` method that allows you to customize its store:
+
+```js
+app.service('todos').vuex({
+  state: {
+    isCompleted: false
+  },
+  getters: {
+    oneTwoThree (state) {
+      return 123
+    }
+  },
+  mutations: {
+    setToTrue (state) {
+      state.isCompleted = true
+    }
+  },
+  actions: {
+    triggerSetToTrue (context) {
+      context.commit('setToTrue')
+    }
+  }
+})
+
+assert(store.getters['todos/oneTwoThree'] === 123, 'the custom getter was available')
+store.dispatch('todos/trigger')
+assert(store.state.todos.isTrue === true, 'the custom action was run')
 ```
 
 ## Auth Module

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -1,6 +1,7 @@
 export default function makeServiceActions (service) {
   const { vuexOptions } = service
   const idField = vuexOptions.module.idField || vuexOptions.global.idField
+  const customActions = (vuexOptions.module && vuexOptions.module.actions) || {}
 
   const serviceActions = {
     find ({ commit, dispatch }, params) {
@@ -166,7 +167,9 @@ export default function makeServiceActions (service) {
       checkId(id, item)
 
       existingItem ? commit('updateItem', item) : commit('addItem', item)
-    }
+    },
+
+    ...customActions
   }
   Object.keys(serviceActions).map(method => {
     if (typeof service[method] === 'function') {

--- a/src/service-module/getters.js
+++ b/src/service-module/getters.js
@@ -4,6 +4,7 @@ import { sorter, matcher, select, _ } from 'feathers-commons'
 export default function makeServiceGetters (service) {
   const { vuexOptions } = service
   const idField = vuexOptions.module.idField || vuexOptions.global.idField
+  const customGetters = (vuexOptions.module && vuexOptions.module.getters) || {}
 
   return {
     list (state) {
@@ -44,6 +45,8 @@ export default function makeServiceGetters (service) {
     },
     current (state) {
       return state.currentId ? state.keyedById[state.currentId] : null
-    }
+    },
+
+    ...customGetters
   }
 }

--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -5,6 +5,7 @@ import isObject from 'lodash.isobject'
 export default function makeServiceMutations (service) {
   const { vuexOptions } = service
   const idField = vuexOptions.module.idField || vuexOptions.global.idField
+  const customMutations = (vuexOptions.module && vuexOptions.module.mutations) || {}
 
   function addItem (state, item) {
     let id = item[idField]
@@ -219,6 +220,8 @@ export default function makeServiceMutations (service) {
     },
     clearRemoveError (state) {
       state.errorOnRemove = undefined
-    }
+    },
+
+    ...customMutations
   }
 }

--- a/src/service-module/state.js
+++ b/src/service-module/state.js
@@ -1,6 +1,7 @@
 export default service => {
   const vuexOptions = service.vuexOptions
   const idField = (vuexOptions.module && vuexOptions.module.idField) || vuexOptions.global.idField
+  const customState = (vuexOptions.module && vuexOptions.module.state) || {}
 
   const state = {
     ids: [],
@@ -21,7 +22,8 @@ export default service => {
     errorOnCreate: undefined,
     errorOnUpdate: undefined,
     errorOnPatch: undefined,
-    errorOnRemove: undefined
+    errorOnRemove: undefined,
+    ...customState
   }
   return state
 }

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -276,4 +276,93 @@ describe('Service Module', () => {
       })
     })
   })
+
+  describe('Customizing Service Stores', function () {
+    it('allows adding custom state', function () {
+      const store = makeStore()
+      const feathersClient = makeFeathersRestClient()
+        .configure(feathersVuex(store, {idField: '_id'}))
+      const service = feathersClient.service('todos', {
+        state: makeTodos()
+      })
+
+      service.vuex({
+        state: {
+          thisIsATest: true
+        }
+      })
+
+      assert(store.state.todos.thisIsATest === true, 'the custom state was mixed into the store')
+    })
+
+    it('allows adding custom mutations', function () {
+      const store = makeStore()
+      const feathersClient = makeFeathersRestClient()
+        .configure(feathersVuex(store, {idField: '_id'}))
+      const service = feathersClient.service('todos', {
+        state: makeTodos()
+      })
+
+      service.vuex({
+        state: {
+          thisIsATest: true
+        },
+        mutations: {
+          disableThisIsATest (state) {
+            state.thisIsATest = false
+          }
+        }
+      })
+
+      store.commit('todos/disableThisIsATest')
+      assert(store.state.todos.thisIsATest === false, 'the custom state was modified by the custom mutation')
+    })
+
+    it('allows adding custom getters', function () {
+      const store = makeStore()
+      const feathersClient = makeFeathersRestClient()
+        .configure(feathersVuex(store, {idField: '_id'}))
+      const service = feathersClient.service('todos', {
+        state: makeTodos()
+      })
+
+      service.vuex({
+        getters: {
+          oneTwoThree (state) {
+            return 123
+          }
+        }
+      })
+
+      assert(store.getters['todos/oneTwoThree'] === 123, 'the custom getter was available')
+    })
+
+    it('allows adding custom actions', function () {
+      const store = makeStore()
+      const feathersClient = makeFeathersRestClient()
+        .configure(feathersVuex(store, {idField: '_id'}))
+      const service = feathersClient.service('todos', {
+        state: makeTodos()
+      })
+
+      service.vuex({
+        state: {
+          isTrue: false
+        },
+        mutations: {
+          setToTrue (state) {
+            state.isTrue = true
+          }
+        },
+        actions: {
+          trigger (context) {
+            context.commit('setToTrue')
+          }
+        }
+      })
+
+      store.dispatch('todos/trigger')
+      assert(store.state.todos.isTrue === true, 'the custom action was run')
+    })
+  })
 })


### PR DESCRIPTION
Allows you to add `state`, `getters`, `mutations`, or `actions` to augment the default store of a services Vuex module.