### PR TITLE
Return Promise.reject for action path of services when catching an er…

### DIFF
--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -103,7 +103,7 @@ export default function makeServiceActions (service) {
         .catch(error => {
           commit('setPatchError', Object.assign({}, error))
           commit('unsetPatchPending')
-          return error
+          return Promise.reject(error)
         })
     },
 


### PR DESCRIPTION
This commit resolves the issue with patch action. The action does not return a Promise.reject on catch.