### PR TITLE
Support array namespaces for module nesting

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">= 4.6.0"
   },
   "scripts": {
+    "prepare": "npm run compile",
     "prepublish": "npm run compile",
     "publish": "git push origin --tags && npm run changelog && git push origin",
     "release:patch": "npm version patch && npm publish",
@@ -72,7 +73,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",
     "lodash.merge": "^4.6.0",
-    "lodash.topath": "^4.5.2",
     "lodash.trim": "^4.5.1",
     "rubberduck": "^1.1.1",
     "serialize-error": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
     "lib": "lib"
   },
   "dependencies": {
-    "clone": "^2.1.1",
     "debug": "^2.6.3",
-    "deep-assign": "^2.0.0",
     "feathers-commons": "^0.8.7",
     "feathers-errors": "^2.6.3",
     "feathers-query-filters": "^2.1.2",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",
+    "lodash.merge": "^4.6.0",
     "rubberduck": "^1.1.1",
     "serialize-error": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",
     "lodash.merge": "^4.6.0",
+    "lodash.topath": "^4.5.2",
+    "lodash.trim": "^4.5.1",
     "rubberduck": "^1.1.1",
     "serialize-error": "^2.1.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import rubberduck from 'rubberduck/dist/rubberduck'
 import setupServiceModule from './service-module/service-module'
 import setupAuthModule from './auth-module/auth-module'
-import deepAssign from 'deep-assign'
-import clone from 'clone'
+import _merge from 'lodash.merge'
+import _cloneDeep from 'lodash.clonedeep'
 import { normalizePath, makeConfig } from './utils'
 
 const defaultOptions = {
@@ -21,8 +21,8 @@ const defaultOptions = {
 }
 
 export default function (clientOrStore, options = {}, modules = {}) {
-  var theClone = clone(defaultOptions)
-  options = deepAssign(theClone, options)
+  var theClone = _cloneDeep(defaultOptions)
+  options = _merge(theClone, options)
 
   return function feathersVuex (arg) {
     const asFeathersPlugin = !arg

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,9 @@ export default function (clientOrStore, options = {}, modules = {}) {
       throw new Error('You must pass a Feathers Client instance to the Feathers-Vuex plugin.')
     }
 
-    // Normalize the modules into objects if they were provided as a string.
+    // Normalize the modules into objects if they were provided as a string or an array
     Object.keys(modules).forEach(namespace => {
-      if (typeof modules[namespace] === 'string') {
+      if (typeof modules[namespace] === 'string' || Array.isArray(modules[namespace])) {
         modules[namespace] = { namespace: modules[namespace] }
       }
     })

--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -1,4 +1,5 @@
-import deepAssign from 'deep-assign'
+import _merge from 'lodash.merge'
+import _cloneDeep from 'lodash.clonedeep'
 import serializeError from 'serialize-error'
 import isObject from 'lodash.isobject'
 
@@ -128,7 +129,7 @@ export default function makeServiceMutations (service) {
     setCurrent (state, item) {
       let id = isObject(item) ? item[idField] : item
       state.currentId = id
-      state.copy = deepAssign({}, item)
+      state.copy = _cloneDeep(item)
     },
 
     clearCurrent (state) {
@@ -139,13 +140,13 @@ export default function makeServiceMutations (service) {
     // Deep assigns current to copy
     rejectCopy (state) {
       let current = state.keyedById[state.currentId]
-      deepAssign(state.copy, current)
+      _merge(state.copy, current)
     },
 
     // Deep assigns copy to current
     commitCopy (state) {
       let current = state.keyedById[state.currentId]
-      deepAssign(current, state.copy)
+      _merge(current, state.copy)
     },
 
     setFindPending (state) {

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -1,4 +1,4 @@
-import { getShortName, getNameFromPath, getNameFromConfig } from '../utils'
+import { getShortName, getNameFromPath, getNameFromExplicit } from '../utils'
 import _merge from 'lodash.merge'
 import makeState from './state'
 import makeGetters from './getters'
@@ -11,7 +11,7 @@ export default function setupServiceModule (store) {
     const nameStyles = {
       short: getShortName,
       path: getNameFromPath,
-      explicit: getNameFromConfig
+      explicit: getNameFromExplicit
     }
     let namespace = nameStyles[vuexOptions.global.nameStyle](service)
     const existingName = service.vuexOptions.module.oldName

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -1,5 +1,5 @@
 import { getShortName, getNameFromPath, getNameFromConfig } from '../utils'
-import deepAssign from 'deep-assign'
+import _merge from 'lodash.merge'
 import makeState from './state'
 import makeGetters from './getters'
 import makeMutations from './mutations'
@@ -23,7 +23,7 @@ export default function setupServiceModule (store) {
     }
 
     // update the name
-    deepAssign(service.vuexOptions, { module: {namespace} })
+    _merge(service.vuexOptions, { module: {namespace} })
     vuexOptions.modules[service.path] = vuexOptions.module
 
     // Setup or re-setup the module if .vuex() was called manually.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,9 @@
 import _merge from 'lodash.merge'
 import _cloneDeep from 'lodash.clonedeep'
+import _trim from 'lodash.trim'
+
 export function stripSlashes (location) {
-  return location.replace(/^(\/*)|(\/*)$/g, '')
+  return Array.isArray(location) ? location.map(l => _trim(l, '/')) : _trim(location, '/')
 }
 
 export function normalizePath (service, location) {
@@ -13,34 +15,40 @@ export function upperCaseFirst (string) {
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
 
+export function getNameFromConfig (service) {
+  return service.vuexOptions.module && service.vuexOptions.module.namespace
+}
+
 export function getShortName (service) {
   // If a name was manually provided, use it.
-  let explicitName = service.vuexOptions.module && service.vuexOptions.module.namespace
-  if (explicitName) {
-    return stripSlashes(explicitName)
+  let namespace = getNameFromConfig(service)
+  if (namespace) {
+    return stripSlashes(namespace)
   }
 
   // Otherwise, create a short name.
-  let location = stripSlashes(service.path)
-  if (location.includes('/')) {
-    location = location.slice(location.lastIndexOf('/') + 1)
+  namespace = stripSlashes(service.path)
+  if (Array.isArray(namespace)) {
+    namespace = namespace.slice(-1);
+  } else if (namespace.includes('/')) {
+    namespace = namespace.slice(namespace.lastIndexOf('/') + 1)
   }
-  return location
+  return namespace
 }
 
 export function getNameFromPath (service) {
   // If a name was manually provided, use it.
-  let explicitName = service.vuexOptions.module && service.vuexOptions.module.namespace
-  if (explicitName) {
-    return stripSlashes(explicitName)
+  let namespace = getNameFromConfig(service)
+  if (namespace) {
+    return stripSlashes(namespace)
   }
 
   // Otherwise return the full service path.
   return service.path
 }
 
-export function getNameFromConfig (service) {
-  const namespace = service.vuexOptions.module && service.vuexOptions.module.namespace
+export function getNameFromExplicit (service) {
+  const namespace = getNameFromConfig(service)
   if (!namespace) {
     throw new Error(`The feathers-vuex nameStyle attribute is set to explicit, but no name was provided for the ${service.path} service.`)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
-import deepAssign from 'deep-assign'
-
+import _merge from 'lodash.merge'
+import _cloneDeep from 'lodash.clonedeep'
 export function stripSlashes (location) {
   return location.replace(/^(\/*)|(\/*)$/g, '')
 }
@@ -57,7 +57,7 @@ export function makeConfig (options, modules) {
 
     // moduleOptions (passed to the vuex method) will overwrite previous options.
     if (moduleOptions) {
-      deepAssign(modules[service.path], moduleOptions)
+      _merge(modules[service.path], moduleOptions)
     }
 
     // Make the config available on the service.


### PR DESCRIPTION
### Summary
This PR addresses two issues, #15 and #34, by
 * replacing `deep-assign` and `clone` dependencies with `lodash.merge` and `lodash.clonedeep`
 * refactoring the namespace resolution utils to support array namespaces and to be more DRY
 * refactoring `stripSlashes()` in `utils` to support arrays and use `lodash.trim` instead of the regex