### PR TITLE
Fix missing idField

### DIFF
--- a/src/service-module/getters.js
+++ b/src/service-module/getters.js
@@ -36,7 +36,7 @@ export default function makeServiceGetters (servicePath) {
         data: values
       }
     },
-    get: ({ keyedById }) => (id, params = {}) => {
+    get: ({ keyedById, idField }) => (id, params = {}) => {
       return keyedById[id] ? select(params, idField)(keyedById[id]) : undefined
     },
     current (state) {


### PR DESCRIPTION
The `get` method of the `service-module` `getters` do not pass `idField` to the select function.
